### PR TITLE
Support for actively maintained PHP, Laravel versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,25 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php:
-          - '8.0'
-          - '8.1'
-        laravel:
-          - 8.*
-          - 9.*
-        prefer:
-          - 'prefer-lowest'
-          - 'prefer-stable'
-        include:
-          - laravel: '8.*'
-            testbench: '6.*'
-          - laravel: '9.*'
-            testbench: '7.*'
+        php: [8.2, 8.3, 8.4]
+        laravel: [11, 12]
+        prefer: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} --${{ matrix.prefer }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -46,7 +35,7 @@ jobs:
         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
         coverage: pcov
 
-    - uses: actions/cache@v3.0.5
+    - uses: actions/cache@v4
       name: Cache dependencies
       with:
         path: ~/.composer/cache/files
@@ -54,21 +43,26 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-        composer update --${{ matrix.prefer }} --prefer-dist --no-interaction --no-suggest
+        composer require "laravel/framework:^${{ matrix.laravel }}.0" --dev "orchestra/testbench" --no-interaction --${{ matrix.prefer }} --prefer-dist
 
     - name: Setup in-cluster config
+      env:
+        TEST_TOKEN: some-token
+        TEST_CERT: c29tZS1jZXJ0Cg==
+        TEST_NAMESPACE: some-namespace
       run: |
         sudo mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
-        echo "some-token" | sudo tee /var/run/secrets/kubernetes.io/serviceaccount/token
-        echo "c29tZS1jZXJ0Cg==" | sudo tee /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        echo "some-namespace" | sudo tee /var/run/secrets/kubernetes.io/serviceaccount/namespace
-        sudo chmod -R 777 /var/run/secrets/kubernetes.io/serviceaccount/
+        echo "$TEST_TOKEN" | sudo tee /var/run/secrets/kubernetes.io/serviceaccount/token
+        echo "$TEST_CERT" | sudo tee /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        echo "$TEST_NAMESPACE" | sudo tee /var/run/secrets/kubernetes.io/serviceaccount/namespace
+        sudo chmod 644 /var/run/secrets/kubernetes.io/serviceaccount/token
+        sudo chmod 644 /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        sudo chmod 644 /var/run/secrets/kubernetes.io/serviceaccount/namespace
 
     - name: Run tests
       run: |
         vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
-    - uses: codecov/codecov-action@v3.1.0
+    - uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 database.sqlite
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,14 @@
             "role": "Developer"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ryancco/php-k8s.git"
+        }
+    ],
     "require": {
-        "renoki-co/php-k8s": "^3.7"
+        "renoki-co/php-k8s": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -36,10 +42,10 @@
         "test": "vendor/bin/phpunit"
     },
     "require-dev": {
-        "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^6.28|^7.0",
-        "orchestra/testbench-core": "^6.28|^7.0",
-        "phpunit/phpunit": "^9.5.21"
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench-core": "^9.0|^10.0",
+        "phpunit/phpunit": "^10.5|^11.0"
     },
     "config": {
         "sort-packages": true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         failOnRisky="true"
+         failOnWarning="true">
     <testsuites>
         <testsuite name="Renoki Co Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+
     <php>
-        <server name="APP_ENV" value="testing" />
+        <server name="APP_ENV" value="testing"/>
     </php>
+
+    <source restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace RenokiCo\LaravelK8s\Test;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use RenokiCo\LaravelK8s\LaravelK8sFacade;
 use RenokiCo\PhpK8s\Kinds\K8sResource;
 
@@ -131,10 +132,8 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('some-namespace', K8sResource::$defaultNamespace);
     }
 
-    /**
-     * @dataProvider environmentVariableContextProvider
-     */
-    public function test_from_environment_variable(string $context = null, string $expectedDomain)
+    #[DataProvider('environmentVariableContextProvider')]
+    public function test_from_environment_variable(?string $context, string $expectedDomain)
     {
         $_SERVER['KUBECONFIG'] = __DIR__.'/cluster/kubeconfig.yaml::'.__DIR__.'/cluster/kubeconfig-2.yaml';
 
@@ -149,7 +148,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame("https://{$expectedDomain}:8443/?", $cluster->getCallableUrl('/', []));
     }
 
-    public function environmentVariableContextProvider(): iterable
+    public static function environmentVariableContextProvider(): iterable
     {
         yield [null, 'minikube'];
         yield ['minikube-2', 'minikube-2'];


### PR DESCRIPTION
- Dropped support for unsupported versions
- Added support for all actively supported versions
- Addressed outdated actions used in CI
- Addressed deprecations causing tests to fail

This PR accompanies https://github.com/renoki-co/php-k8s/pull/474

All tests passing [here](https://github.com/ryancco/laravel-php-k8s/actions/runs/17870881465)